### PR TITLE
Add shortcut for build config

### DIFF
--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaConfigBuilder.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaConfigBuilder.java
@@ -178,4 +178,8 @@ public class DomaConfigBuilder {
 		this.entityListenerProvider = entityListenerProvider;
 		return this;
 	}
+
+	public DomaConfig build() {
+	    return new DomaConfig(this);
+	}
 }

--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaProperties.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaProperties.java
@@ -88,6 +88,13 @@ public class DomaProperties {
 		this.exceptionTranslationEnabled = exceptionTranslationEnabled;
 	}
 
+    public DomaConfigBuilder initializeDomaConfigBuilder() {
+        return new DomaConfigBuilder()
+                .dialect(dialect.create())
+                .sqlFileRepository(sqlFileRepository.create())
+                .naming(naming.naming());
+    }
+
 	public static enum DialectType {
 		STANDARD(StandardDialect::new), SQLITE(SqliteDialect::new), DB2(Db2Dialect::new), MSSQL(
 				MssqlDialect::new), MSSQL2008(Mssql2008Dialect::new), MYSQL(


### PR DESCRIPTION
コードで`DomaConfig`を生成する場合、今は次のようになります。

```java
@Bean
Config config(EntityListenerProvider entityListenerProvider) {
    DomaConfigBuilder builder = new DomaConfigBuilder()
            .dataSource(dataSource())
            .dialect(domaProperties().getDialect().create())
            .sqlFileRepository(domaProperties().getSqlFileRepository().create())
            .naming(domaProperties().getNaming().naming())
            .entityListenerProvider(entityListenerProvider);
    return new DomaConfig(builder);
}
```

これを次のように書けるようにするのが目的です。

```java
@Bean
Config config(EntityListenerProvider entityListenerProvider) {
    return domaProperties().initializeDomaConfigBuilder()
            .dataSource(dataSource())
            .entityListenerProvider(entityListenerProvider)
            .build();
}
```

主に複数の`Config`を必要とする場合に設定の見通しを良くするために使用する想定です。

`DataSourceProperties`を参考にしました。

* https://github.com/spring-projects/spring-boot/blob/v1.5.1.RELEASE/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceProperties.java#L181
* https://github.com/spring-projects/spring-boot/blob/v1.5.1.RELEASE/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/jdbc/DataSourceBuilder.java#L68