### PR TITLE
remove unnecessary @ConfigurationProperties

### DIFF
--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfiguration.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfiguration.java
@@ -91,7 +91,6 @@ public class DomaAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(Config.class)
-	@ConfigurationProperties(prefix = DOMA_PREFIX)
 	public DomaConfig config(DataSource dataSource, Dialect dialect,
 			SqlFileRepository sqlFileRepository, Naming naming,
 			EntityListenerProvider entityListenerProvider,


### PR DESCRIPTION
@ConfigurationProperties is not necessary at DomaAutoConfiguration#config 
And, application startup is failed in Spring Boot 2.0.0M2