### PR TITLE
Use Doma 2.19.x latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <doma.version>2.19.1</doma.version>
+        <doma.version>[2.19.1,2.20.0)</doma.version>
         <spring-boot.version>1.5.10.RELEASE</spring-boot.version>
         <rootDir>${project.basedir}</rootDir>
     </properties>


### PR DESCRIPTION
提案です。

Spring Bootを利用したプロジェクトでDomaを採用したい開発者にとって、2.19.x系の最新バージョンが依存として登録されていた方が嬉しいのではないかと考えて、[Maven Dependency Version Requirement Specification](https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification)を参考に、最新のDoma 2.19.xを利用するように変更しました。

Doma本体の[リリースノート](https://doma.readthedocs.io/ja/stable/release-notes/)も拝見して、少なくともAPIの破壊的な変更は入っておらず、常に2.19.x系の最新バージョンを使えた方が良いと思った次第です。

2018-11現在、手元で `./mvnw dependency:tree` コマンドを実行してみた結果は、次の通りです。

修正前：

```bash
$ ./mvnw dependency:tree
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ doma-spring-boot-core ---
[INFO] org.seasar.doma.boot:doma-spring-boot-core:jar:1.2.0-SNAPSHOT
[INFO] +- org.seasar.doma:doma:jar:2.19.1:compile
[INFO] +- org.springframework:spring-context:jar:4.3.14.RELEASE:compile
[INFO] |  +- org.springframework:spring-aop:jar:4.3.14.RELEASE:compile
[INFO] |  +- org.springframework:spring-beans:jar:4.3.14.RELEASE:compile
[INFO] |  +- org.springframework:spring-core:jar:4.3.14.RELEASE:compile
[INFO] |  |  \- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  \- org.springframework:spring-expression:jar:4.3.14.RELEASE:compile
[INFO] +- org.springframework:spring-jdbc:jar:4.3.14.RELEASE:compile
[INFO] |  \- org.springframework:spring-tx:jar:4.3.14.RELEASE:compile
[INFO] +- org.springframework.data:spring-data-commons:jar:1.13.10.RELEASE:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.25:compile
[INFO] |  \- org.slf4j:jcl-over-slf4j:jar:1.7.25:runtime
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.assertj:assertj-core:jar:2.6.0:test
[INFO] +- org.mockito:mockito-core:jar:1.10.19:test
[INFO] |  \- org.objenesis:objenesis:jar:2.1:test
[INFO] \- com.h2database:h2:jar:1.4.196:test
```

修正後：

```bash
$ ./mvnw dependency:tree
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ doma-spring-boot-core ---
[INFO] org.seasar.doma.boot:doma-spring-boot-core:jar:1.2.0-SNAPSHOT
[INFO] +- org.seasar.doma:doma:jar:2.19.3:compile
[INFO] +- org.springframework:spring-context:jar:4.3.14.RELEASE:compile
[INFO] |  +- org.springframework:spring-aop:jar:4.3.14.RELEASE:compile
[INFO] |  +- org.springframework:spring-beans:jar:4.3.14.RELEASE:compile
[INFO] |  +- org.springframework:spring-core:jar:4.3.14.RELEASE:compile
[INFO] |  |  \- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  \- org.springframework:spring-expression:jar:4.3.14.RELEASE:compile
[INFO] +- org.springframework:spring-jdbc:jar:4.3.14.RELEASE:compile
[INFO] |  \- org.springframework:spring-tx:jar:4.3.14.RELEASE:compile
[INFO] +- org.springframework.data:spring-data-commons:jar:1.13.10.RELEASE:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.25:compile
[INFO] |  \- org.slf4j:jcl-over-slf4j:jar:1.7.25:runtime
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.assertj:assertj-core:jar:2.6.0:test
[INFO] +- org.mockito:mockito-core:jar:1.10.19:test
[INFO] |  \- org.objenesis:objenesis:jar:2.1:test
[INFO] \- com.h2database:h2:jar:1.4.196:test
```