### PR TITLE
Improve Dialect configuration

### DIFF
--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfiguration.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfiguration.java
@@ -17,6 +17,8 @@ package org.seasar.doma.boot.autoconfigure;
 
 import javax.sql.DataSource;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.seasar.doma.boot.DomaPersistenceExceptionTranslator;
 import org.seasar.doma.boot.TryLookupEntityListenerProvider;
 import org.seasar.doma.boot.autoconfigure.DomaProperties.DialectType;
@@ -65,6 +67,8 @@ import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
 @AutoConfigureAfter(DataSourceAutoConfiguration.class)
 public class DomaAutoConfiguration {
 
+	private static final Log logger = LogFactory.getLog(DomaAutoConfiguration.class);
+
 	@Autowired
 	private DomaProperties domaProperties;
 
@@ -99,6 +103,10 @@ public class DomaAutoConfiguration {
 			default:
 				break;
 			}
+		}
+		if (logger.isWarnEnabled()) {
+			logger.warn(
+					"StandardDialect was selected because no explicit configuration and it is not possible to guess from 'spring.datasource.url property'");
 		}
 		return new StandardDialect();
 	}

--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfiguration.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfiguration.java
@@ -16,8 +16,10 @@
 package org.seasar.doma.boot.autoconfigure;
 
 import javax.sql.DataSource;
+
 import org.seasar.doma.boot.DomaPersistenceExceptionTranslator;
 import org.seasar.doma.boot.TryLookupEntityListenerProvider;
+import org.seasar.doma.boot.autoconfigure.DomaProperties.DialectType;
 import org.seasar.doma.boot.event.DomaEventEntityListener;
 import org.seasar.doma.boot.event.DomaEventListenerFactory;
 import org.seasar.doma.jdbc.Config;
@@ -26,7 +28,16 @@ import org.seasar.doma.jdbc.Naming;
 import org.seasar.doma.jdbc.SqlFileRepository;
 import org.seasar.doma.jdbc.criteria.Entityql;
 import org.seasar.doma.jdbc.criteria.NativeSql;
+import org.seasar.doma.jdbc.dialect.Db2Dialect;
 import org.seasar.doma.jdbc.dialect.Dialect;
+import org.seasar.doma.jdbc.dialect.H2Dialect;
+import org.seasar.doma.jdbc.dialect.HsqldbDialect;
+import org.seasar.doma.jdbc.dialect.MssqlDialect;
+import org.seasar.doma.jdbc.dialect.MysqlDialect;
+import org.seasar.doma.jdbc.dialect.OracleDialect;
+import org.seasar.doma.jdbc.dialect.PostgresDialect;
+import org.seasar.doma.jdbc.dialect.SqliteDialect;
+import org.seasar.doma.jdbc.dialect.StandardDialect;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -34,8 +45,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.jdbc.DatabaseDriver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
 
@@ -56,8 +69,37 @@ public class DomaAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
-	public Dialect dialect() {
-		return domaProperties.getDialect().create();
+	public Dialect dialect(Environment environment) {
+		DialectType dialectType = domaProperties.getDialect();
+		if (dialectType != null) {
+			return dialectType.create();
+		}
+		String url = environment.getProperty("spring.datasource.url");
+		if (url != null) {
+			DatabaseDriver databaseDriver = DatabaseDriver.fromJdbcUrl(url);
+			switch (databaseDriver) {
+			case DB2:
+				return new Db2Dialect();
+			case H2:
+				return new H2Dialect();
+			case HSQLDB:
+				return new HsqldbDialect();
+			case SQLSERVER:
+			case JTDS:
+				return new MssqlDialect();
+			case MYSQL:
+				return new MysqlDialect();
+			case ORACLE:
+				return new OracleDialect();
+			case POSTGRESQL:
+				return new PostgresDialect();
+			case SQLITE:
+				return new SqliteDialect();
+			default:
+				break;
+			}
+		}
+		return new StandardDialect();
 	}
 
 	@Bean
@@ -128,20 +170,20 @@ public class DomaAutoConfiguration {
 		return domaConfigBuilder.build();
 	}
 
-    @Configuration
-    @ConditionalOnClass({ Entityql.class, NativeSql.class })
-    public static class CriteriaConfiguration {
+	@Configuration
+	@ConditionalOnClass({ Entityql.class, NativeSql.class })
+	public static class CriteriaConfiguration {
 
-        @Bean
-        @ConditionalOnMissingBean(Entityql.class)
-        public Entityql entityql(Config config) {
-            return new Entityql(config);
-        }
+		@Bean
+		@ConditionalOnMissingBean(Entityql.class)
+		public Entityql entityql(Config config) {
+			return new Entityql(config);
+		}
 
-        @Bean
-        @ConditionalOnMissingBean(NativeSql.class)
-        public NativeSql nativeSql(Config config) {
-            return new NativeSql(config);
-        }
-    }
+		@Bean
+		@ConditionalOnMissingBean(NativeSql.class)
+		public NativeSql nativeSql(Config config) {
+			return new NativeSql(config);
+		}
+	}
 }

--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfiguration.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfiguration.java
@@ -64,6 +64,7 @@ import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
 @EnableConfigurationProperties(DomaProperties.class)
 @AutoConfigureAfter(DataSourceAutoConfiguration.class)
 public class DomaAutoConfiguration {
+
 	@Autowired
 	private DomaProperties domaProperties;
 

--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaProperties.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaProperties.java
@@ -35,7 +35,7 @@ public class DomaProperties {
 	/**
 	 * Dialect of database used by Doma.
 	 */
-	private DialectType dialect = DialectType.STANDARD;
+	private DialectType dialect;
 
 	/**
 	 * Type of {@link SqlFileRepository}.


### PR DESCRIPTION
The default value for `Dialect` has been improved.

`Dialect` is determined based on spring.datasource.url property, if all of the following conditions are true:

- Missing `Dialect` bean
- `DomaProperties.getDialect` return `null`
- `spring.datasource.url` property exists
