### PR TITLE
Support Slf4jJdbcLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ doma.fetch-size=0 # Hint to the number of rows that should be fetched. Ignored u
 doma.batch-size=0 # Size in executing PreparedStatement#addBatch(). Regarded as 1 unless this value is greater than 1.
 doma.data-source-name= # Datasource name.
 doma.exception-sql-log-type= # Type of SQL log in the exception. (RAW, FORMATTED, NONE)
+doma.jdbc-logger= # Type of JdbcLogger. (SLF4J, JUL)
 ```
 
 ## Issue Tracking

--- a/doma-spring-boot-autoconfigure/pom.xml
+++ b/doma-spring-boot-autoconfigure/pom.xml
@@ -29,6 +29,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.seasar.doma</groupId>
+            <artifactId>doma-slf4j</artifactId>
+            <version>${doma.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
         </dependency>

--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfiguration.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.seasar.doma.boot.event.DomaEventEntityListener;
 import org.seasar.doma.boot.event.DomaEventListenerFactory;
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.EntityListenerProvider;
+import org.seasar.doma.jdbc.JdbcLogger;
 import org.seasar.doma.jdbc.Naming;
 import org.seasar.doma.jdbc.SqlFileRepository;
 import org.seasar.doma.jdbc.criteria.Entityql;
@@ -131,6 +132,12 @@ public class DomaAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
+	public JdbcLogger jdbcLogger() {
+		return domaProperties.getJdbcLogger().create();
+	}
+
+	@Bean
 	public static DomaEventListenerFactory domaEventListenerFactory() {
 		return new DomaEventListenerFactory();
 	}
@@ -155,7 +162,7 @@ public class DomaAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(Config.class)
 	public DomaConfig config(DataSource dataSource, Dialect dialect,
-			SqlFileRepository sqlFileRepository, Naming naming,
+			SqlFileRepository sqlFileRepository, Naming naming, JdbcLogger jdbcLogger,
 			EntityListenerProvider entityListenerProvider,
 			DomaConfigBuilder domaConfigBuilder) {
 		if (domaConfigBuilder.dataSource() == null) {
@@ -169,6 +176,9 @@ public class DomaAutoConfiguration {
 		}
 		if (domaConfigBuilder.naming() == null) {
 			domaConfigBuilder.naming(naming);
+		}
+		if (domaConfigBuilder.jdbcLogger() == null) {
+			domaConfigBuilder.jdbcLogger(jdbcLogger);
 		}
 		if (domaConfigBuilder.entityListenerProvider() == null) {
 			domaConfigBuilder.entityListenerProvider(entityListenerProvider);

--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaConfigBuilder.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaConfigBuilder.java
@@ -33,7 +33,10 @@ public class DomaConfigBuilder {
 	 * Default value is set in {@link DomaProperties}
 	 */
 	private Dialect dialect;
-	private JdbcLogger jdbcLogger = ConfigSupport.defaultJdbcLogger;
+	/**
+	 * Default value is set in {@link DomaProperties}
+	 */
+	private JdbcLogger jdbcLogger;
 	/**
 	 * Default value is set in {@link DomaProperties}
 	 */

--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaProperties.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaProperties.java
@@ -64,6 +64,11 @@ public class DomaProperties {
 	private SqlLogType exceptionSqlLogType = SqlLogType.NONE;
 
 	/**
+	 * Type of {@link JdbcLogger}.
+	 */
+	private JdbcLoggerType jdbcLogger = JdbcLoggerType.SLF4J;
+
+	/**
 	 * Limit for the maximum number of rows. Ignored unless this value is greater than 0.
 	 */
 	private int maxRows = 0;
@@ -129,6 +134,14 @@ public class DomaProperties {
 
 	public void setExceptionSqlLogType(SqlLogType exceptionSqlLogType) {
 		this.exceptionSqlLogType = exceptionSqlLogType;
+	}
+
+	public JdbcLoggerType getJdbcLogger() {
+		return jdbcLogger;
+	}
+
+	public void setJdbcLogger(JdbcLoggerType jdbcLogger) {
+		this.jdbcLogger = jdbcLogger;
 	}
 
 	public int getMaxRows() {
@@ -227,13 +240,29 @@ public class DomaProperties {
 		}
 	}
 
+	public static enum JdbcLoggerType {
+		JUL(UtilLoggingJdbcLogger::new),
+		SLF4J(Slf4jJdbcLogger::new);
+
+		private final Supplier<JdbcLogger> constructor;
+
+		JdbcLoggerType(Supplier<JdbcLogger> constructor) {
+			this.constructor = constructor;
+		}
+
+		public JdbcLogger create() {
+			return this.constructor.get();
+		}
+	}
+
 	@Override
 	public String toString() {
 		return "DomaProperties{" + "dialect=" + dialect + ", sqlFileRepository="
 				+ sqlFileRepository + ", naming=" + naming
 				+ ", exceptionTranslationEnabled=" + exceptionTranslationEnabled
 				+ ", dataSourceName='" + dataSourceName + '\'' + ", exceptionSqlLogType="
-				+ exceptionSqlLogType + ", maxRows=" + maxRows + ", fetchSize="
+				+ exceptionSqlLogType + ", jdbcLogger="
+				+ jdbcLogger + ", maxRows=" + maxRows + ", fetchSize="
 				+ fetchSize + ", queryTimeout=" + queryTimeout + ", batchSize="
 				+ batchSize + '}';
 	}

--- a/doma-spring-boot-autoconfigure/src/test/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfigurationTest.java
+++ b/doma-spring-boot-autoconfigure/src/test/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfigurationTest.java
@@ -34,8 +34,10 @@ import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.EntityListenerProvider;
 import org.seasar.doma.jdbc.GreedyCacheSqlFileRepository;
 import org.seasar.doma.jdbc.JdbcException;
+import org.seasar.doma.jdbc.JdbcLogger;
 import org.seasar.doma.jdbc.Naming;
 import org.seasar.doma.jdbc.NoCacheSqlFileRepository;
+import org.seasar.doma.jdbc.Slf4jJdbcLogger;
 import org.seasar.doma.jdbc.SqlFileRepository;
 import org.seasar.doma.jdbc.UtilLoggingJdbcLogger;
 import org.seasar.doma.jdbc.criteria.Entityql;
@@ -82,7 +84,7 @@ public class DomaAutoConfigurationTest {
 		assertThat(config.getSqlFileRepository(),
 				is(instanceOf(GreedyCacheSqlFileRepository.class)));
 		assertThat(config.getNaming(), is(Naming.DEFAULT));
-		assertThat(config.getJdbcLogger(), is(instanceOf(UtilLoggingJdbcLogger.class)));
+		assertThat(config.getJdbcLogger(), is(instanceOf(Slf4jJdbcLogger.class)));
 		assertThat(config.getEntityListenerProvider(), is(notNullValue()));
 		PersistenceExceptionTranslator translator = this.context
 				.getBean(PersistenceExceptionTranslator.class);
@@ -268,6 +270,7 @@ public class DomaAutoConfigurationTest {
 		DomaConfigBuilder myDomaConfigBuilder(DomaProperties domaProperties) {
 			return new DomaConfigBuilder(domaProperties).dialect(new MysqlDialect())
 					.sqlFileRepository(new NoCacheSqlFileRepository())
+                    .jdbcLogger(new UtilLoggingJdbcLogger())
 					.naming(Naming.SNAKE_UPPER_CASE)
 					.entityListenerProvider(new TestEntityListenerProvider());
 		}
@@ -296,6 +299,11 @@ public class DomaAutoConfigurationTest {
 				@Override
 				public Naming getNaming() {
 					return Naming.SNAKE_LOWER_CASE;
+				}
+
+				@Override
+				public JdbcLogger getJdbcLogger() {
+					return new UtilLoggingJdbcLogger();
 				}
 
 				@Override

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <doma.version>2.35.0</doma.version>
+        <doma.version>2.43.0</doma.version>
         <spring-boot.version>1.5.22.RELEASE</spring-boot.version>
         <rootDir>${project.basedir}</rootDir>
     </properties>


### PR DESCRIPTION
Doma 2.43.0 supports SLF4J.
https://doma.readthedocs.io/en/2.43.0/slf4j-support/

I hope doma-spring-boot also supports it.
This PR makes JdbcLogger configurable and uses SLF4J as the default logger.