### PR TITLE
Change default logger configuration

### DIFF
--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaProperties.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaProperties.java
@@ -66,7 +66,7 @@ public class DomaProperties {
 	/**
 	 * Type of {@link JdbcLogger}.
 	 */
-	private JdbcLoggerType jdbcLogger = JdbcLoggerType.SLF4J;
+	private JdbcLoggerType jdbcLogger = JdbcLoggerType.JUL;
 
 	/**
 	 * Limit for the maximum number of rows. Ignored unless this value is greater than 0.

--- a/doma-spring-boot-autoconfigure/src/test/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfigurationTest.java
+++ b/doma-spring-boot-autoconfigure/src/test/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfigurationTest.java
@@ -37,7 +37,7 @@ import org.seasar.doma.jdbc.JdbcException;
 import org.seasar.doma.jdbc.JdbcLogger;
 import org.seasar.doma.jdbc.Naming;
 import org.seasar.doma.jdbc.NoCacheSqlFileRepository;
-import org.seasar.doma.jdbc.Slf4jJdbcLogger;
+import org.seasar.doma.jdbc.UtilLoggingJdbcLogger;
 import org.seasar.doma.jdbc.SqlFileRepository;
 import org.seasar.doma.jdbc.UtilLoggingJdbcLogger;
 import org.seasar.doma.jdbc.criteria.Entityql;
@@ -84,7 +84,7 @@ public class DomaAutoConfigurationTest {
 		assertThat(config.getSqlFileRepository(),
 				is(instanceOf(GreedyCacheSqlFileRepository.class)));
 		assertThat(config.getNaming(), is(Naming.DEFAULT));
-		assertThat(config.getJdbcLogger(), is(instanceOf(Slf4jJdbcLogger.class)));
+		assertThat(config.getJdbcLogger(), is(instanceOf(UtilLoggingJdbcLogger.class)));
 		assertThat(config.getEntityListenerProvider(), is(notNullValue()));
 		PersistenceExceptionTranslator translator = this.context
 				.getBean(PersistenceExceptionTranslator.class);


### PR DESCRIPTION
If the default logger is SLF4J, [doma-spring-boot-demo](https://github.com/backpaper0/doma-spring-boot-demo) test is fail in some cases.

|doma-spring-boot|Doma|Test result|
|---|---|---|
|`1.4.0`|`2.42.0`|:+1:|
|`1.4.0`|`2.43.0`|:+1:|
|`1.4.0`|`2.44.3`|:+1:|
|`1.5.0-SNAPSHOT`|`2.42.0`|:ng:|
|`1.5.0-SNAPSHOT`|`2.43.0`|:ng:|
|`1.5.0-SNAPSHOT`|`2.44.3`|:+1:|

Change default logger to jul for backward compatibility.