### PR TITLE
Bump Spring Boot versions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        spring-boot-version: [ 2.2.13.RELEASE, 2.3.12.RELEASE, 2.4.13, 2.5.7, 2.6.0 ]
+        spring-boot-version: [ 2.3.12.RELEASE, 2.5.13, 2.5.7, 2.6.7 ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- Remove 2.2.x (End Commercial Support)