### PR TITLE
Change the default logger from java.util.logging to SLF4J

### DIFF
--- a/doma-spring-boot-autoconfigure/pom.xml
+++ b/doma-spring-boot-autoconfigure/pom.xml
@@ -26,7 +26,6 @@
             <groupId>org.seasar.doma</groupId>
             <artifactId>doma-slf4j</artifactId>
             <version>${doma.version}</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaProperties.java
+++ b/doma-spring-boot-autoconfigure/src/main/java/org/seasar/doma/boot/autoconfigure/DomaProperties.java
@@ -75,7 +75,7 @@ public class DomaProperties {
 	/**
 	 * Type of {@link JdbcLogger}.
 	 */
-	private JdbcLoggerType jdbcLogger = JdbcLoggerType.JUL;
+	private JdbcLoggerType jdbcLogger = JdbcLoggerType.SLF4J;
 
 	/**
 	 * Limit for the maximum number of rows. Ignored unless this value is greater than 0.

--- a/doma-spring-boot-autoconfigure/src/test/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfigurationTest.java
+++ b/doma-spring-boot-autoconfigure/src/test/java/org/seasar/doma/boot/autoconfigure/DomaAutoConfigurationTest.java
@@ -56,6 +56,7 @@ import org.seasar.doma.jdbc.dialect.StandardDialect;
 import org.seasar.doma.jdbc.statistic.DefaultStatisticManager;
 import org.seasar.doma.jdbc.statistic.StatisticManager;
 import org.seasar.doma.message.Message;
+import org.seasar.doma.slf4j.Slf4jJdbcLogger;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -92,7 +93,7 @@ public class DomaAutoConfigurationTest {
 		assertThat(config.getSqlFileRepository(),
 				is(instanceOf(GreedyCacheSqlFileRepository.class)));
 		assertThat(config.getNaming(), is(Naming.DEFAULT));
-		assertThat(config.getJdbcLogger(), is(instanceOf(UtilLoggingJdbcLogger.class)));
+		assertThat(config.getJdbcLogger(), is(instanceOf(Slf4jJdbcLogger.class)));
 		assertThat(config.getEntityListenerProvider(), is(notNullValue()));
 		assertThat(config.getDuplicateColumnHandler(),
 				is(ConfigSupport.defaultDuplicateColumnHandler));


### PR DESCRIPTION
# Impact on users

- Users who were using the default setting (`JUL`):
    - It will be switched to `SLF4J`.
    - If they wish to continue using `JUL`, they will need to add explicit configuration.
      ```
      doma.jdbc-logger=JUL
      ```
- Users who were explicitly using `JUL`:
    - `org.seasar.doma:doma-slf4j` will be included as a dependency.
    - To exclude it, they need to explicitly add an `exclusion` in `pom.xml`:
      ```xml
      <dependency>
          <groupId>org.seasar.doma</groupId>
          <artifactId>doma-spring-boot</artifactId>
          <version>x.y.z</version>
          <exclusions>
              <exclusion>
                  <groupId>org.seasar.doma</groupId>
                  <artifactId>doma-slf4j</artifactId>
              </exclusion>
          </exclusions>
      </dependency>
      ```
- Users who were using `SLF4J`:
    - No impact.
    - Explicit configuration is no longer necessary.

# Related Issue

closes gh-287 

# Others

The ["Configuration" page on the wiki](https://github.com/domaframework/doma-spring-boot/wiki/Configuration) needs to be updated.