### PR TITLE
Prepare for Spring Boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <doma.version>3.11.0</doma.version>
-        <spring-boot.version>3.3.10</spring-boot.version>
+        <spring-boot.version>3.5.4</spring-boot.version>
         <source-plugin.version>3.3.1</source-plugin.version>
         <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
         <nexus-staging-plugin.version>1.7.0</nexus-staging-plugin.version>


### PR DESCRIPTION
Upgrade Spring Boot to version 4 by following the migration guide below:
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide

As a preliminary step, this pull request upgrades to version 3.5.